### PR TITLE
Add pytest style test for sendMsg

### DIFF
--- a/tests/test_moteif.py
+++ b/tests/test_moteif.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from tinyos3.message.MoteIF import MoteIF
+from tinyos3.message.Message import Message
+from tinyos3.message.SerialPacket import SerialPacket
+from tinyos3.packet.Serial import Serial
+
+
+class DummyDest:
+    def __init__(self):
+        self.packet = None
+
+    def writePacket(self, packet):
+        self.packet = packet
+
+
+def test_send_msg_constructs_correct_packet():
+    payload = b"\x01\x02\x03"
+    msg = Message(payload)
+    dest = DummyDest()
+
+    with patch("tinyos3.utils.Watcher.Watcher.getInstance", return_value=object()):
+        mote = MoteIF()
+
+    mote.sendMsg(dest, addr=1, amType=2, group=3, msg=msg)
+
+    serial_pkt = SerialPacket(None)
+    serial_pkt.set_header_dest(1)
+    serial_pkt.set_header_group(3)
+    serial_pkt.set_header_type(2)
+    serial_pkt.set_header_length(len(payload))
+    header = serial_pkt.dataGet()[: serial_pkt.offset_data(0)]
+    expected = bytes([Serial.TOS_SERIAL_ACTIVE_MESSAGE_ID]) + header + payload
+
+    assert dest.packet == expected

--- a/tinyos3/message/MoteIF.py
+++ b/tinyos3/message/MoteIF.py
@@ -113,16 +113,14 @@ class MoteIF:
     def sendMsg(self, dest, addr, amType, group, msg):
         try:
             payload = msg.dataGet()
-            msg = SerialPacket(None)
-            msg.set_header_dest(int(addr))
-            msg.set_header_group(int(group))
-            msg.set_header_type(int(amType))
-            msg.set_header_length(len(payload))
+            serial_pkt = SerialPacket(None)
+            serial_pkt.set_header_dest(int(addr))
+            serial_pkt.set_header_group(int(group))
+            serial_pkt.set_header_type(int(amType))
+            serial_pkt.set_header_length(len(payload))
 
-            # from tinyos3.packet.Serial
-            data = chr(Serial.TOS_SERIAL_ACTIVE_MESSAGE_ID)
-            data += msg.dataGet()[0 : msg.offset_data(0)]
-            data += payload
+            header = serial_pkt.dataGet()[0 : serial_pkt.offset_data(0)]
+            data = bytes([Serial.TOS_SERIAL_ACTIVE_MESSAGE_ID]) + header + payload
 
             dest.writePacket(data)
         except Exception as x:


### PR DESCRIPTION
## Summary
- convert sendMsg test to pytest style
- fix `MoteIF.sendMsg` to build serial packet using bytes

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c051cea848327bfdccf5dfad464cd