### PR TITLE
Remove print-and-ignore exception handling

### DIFF
--- a/tinyos3/message/MoteIF.py
+++ b/tinyos3/message/MoteIF.py
@@ -77,55 +77,39 @@ class MoteIF:
         #             for i in packet:
         #                 print ord(i)," ",
         #             print
-        try:
-            # Message.py ignores base_offset, so we'll just chop off
-            # the first byte (the SERIAL_AMTYPE) here.
-            serial_pkt = SerialPacket(packet[1:], data_length=len(packet) - 1)
-        except:
-            traceback.print_exc()
+        # Message.py ignores base_offset, so we'll just chop off
+        # the first byte (the SERIAL_AMTYPE) here.
+        serial_pkt = SerialPacket(packet[1:], data_length=len(packet) - 1)
 
-        try:
-            data_start = serial_pkt.offset_data(0) + 1
-            data_end = data_start + serial_pkt.get_header_length()
-            data = packet[data_start:data_end]
-            amType = serial_pkt.get_header_type()
-
-        except Exception as x:
-            print(x, file=sys.stderr)
-            print(traceback.print_tb(sys.exc_info()[2]), file=sys.stderr)
+        data_start = serial_pkt.offset_data(0) + 1
+        data_end = data_start + serial_pkt.get_header_length()
+        data = packet[data_start:data_end]
+        amType = serial_pkt.get_header_type()
 
         for l in self.listeners:
             amTypes = self.listeners[l]
             if amType in amTypes:
-                try:
-                    msgClass = amTypes[amType]
-                    msg = msgClass(
-                        data=data,
-                        data_length=len(data),
-                        addr=serial_pkt.get_header_src(),
-                        gid=serial_pkt.get_header_group(),
-                    )
-                    l.receive(source, msg)
-                except Exception as x:
-                    print(x, file=sys.stderr)
-                    print(traceback.print_tb(sys.exc_info()[2]), file=sys.stderr)
+                msgClass = amTypes[amType]
+                msg = msgClass(
+                    data=data,
+                    data_length=len(data),
+                    addr=serial_pkt.get_header_src(),
+                    gid=serial_pkt.get_header_group(),
+                )
+                l.receive(source, msg)
 
     def sendMsg(self, dest, addr, amType, group, msg):
-        try:
-            payload = msg.dataGet()
-            serial_pkt = SerialPacket(None)
-            serial_pkt.set_header_dest(int(addr))
-            serial_pkt.set_header_group(int(group))
-            serial_pkt.set_header_type(int(amType))
-            serial_pkt.set_header_length(len(payload))
+        payload = msg.dataGet()
+        serial_pkt = SerialPacket(None)
+        serial_pkt.set_header_dest(int(addr))
+        serial_pkt.set_header_group(int(group))
+        serial_pkt.set_header_type(int(amType))
+        serial_pkt.set_header_length(len(payload))
 
-            header = serial_pkt.dataGet()[0 : serial_pkt.offset_data(0)]
-            data = bytes([Serial.TOS_SERIAL_ACTIVE_MESSAGE_ID]) + header + payload
+        header = serial_pkt.dataGet()[0 : serial_pkt.offset_data(0)]
+        data = bytes([Serial.TOS_SERIAL_ACTIVE_MESSAGE_ID]) + header + payload
 
-            dest.writePacket(data)
-        except Exception as x:
-            print(x, file=sys.stderr)
-            print(traceback.print_tb(sys.exc_info()[2]), file=sys.stderr)
+        dest.writePacket(data)
 
     def addSource(self, name=None):
         if name == None:

--- a/tinyos3/packet/PacketSource.py
+++ b/tinyos3/packet/PacketSource.py
@@ -64,16 +64,6 @@ class PacketSource(ThreadTask):
     def __call__(self):
         try:
             self.open()
-        except Exception as x:
-            if DEBUG:
-                print("Exception while opening packet source:")
-                print(x)
-                print(traceback.print_tb(sys.exc_info()[2]))
-            self.done = True
-        except:
-            if DEBUG:
-                print("Unknown exception while opening packet source")
-            self.done = True
         finally:
             self.semaphore.release()
 
@@ -84,42 +74,18 @@ class PacketSource(ThreadTask):
                 if DEBUG:
                     print("IO finished")
                 break
-            except Exception as x:
-                if DEBUG:
-                    print("IO exception:")
-                    print(x)
-                    print(traceback.print_tb(sys.exc_info()[2]))
-                break
-            except:
-                if DEBUG:
-                    print("Unknown IO exception")
-                break
 
             if packet:
-                try:
-                    if DEBUG:
-                        print("About to run packet dispatcher!")
-                        print(f"packet={packet}")
-                        # for i in packet:
-                        #     print(i, " ", end=" ")
-                        # print()
+                if DEBUG:
+                    print("About to run packet dispatcher!")
+                    print(f"packet={packet}")
+                    # for i in packet:
+                    #     print(i, " ", end=" ")
+                    # print()
 
-                    self.dispatcher.dispatchPacket(self, packet)
-                except Exception as x:
-                    if DEBUG:
-                        print("Exception when dispatching packet:")
-                        print(x)
-                        print(traceback.print_tb(sys.exc_info()[2]))
-                #                    break
-                except:
-                    if DEBUG:
-                        print("Unknown exception when dispatching packet")
-        #                    break
+                self.dispatcher.dispatchPacket(self, packet)
 
-        try:
-            self.close()
-        except:
-            pass
+        self.close()
 
         self.finish()
 

--- a/tinyos3/packet/SocketIO.py
+++ b/tinyos3/packet/SocketIO.py
@@ -70,8 +70,6 @@ class SocketIO(IO):
                 data += self.socket.recv(count - len(data))
             except socket.timeout:
                 pass
-            except Exception as x:
-                print(f"SocketIO Exception in read: {repr(x)}", file=sys.stderr)
 
         return data
 

--- a/tinyos3/utils/Watcher.py
+++ b/tinyos3/utils/Watcher.py
@@ -66,8 +66,4 @@ class Watcher(Singleton):
         sys.exit()
 
     def kill(self):
-        try:
-            os.kill(self.child, signal.SIGKILL)
-        except OSError as x:
-            print("os.kill failed")
-            print(x)
+        os.kill(self.child, signal.SIGKILL)


### PR DESCRIPTION
## Summary
- let `Watcher.kill` raise `OSError`
- remove generic exception handling from `PacketSource.__call__`
- allow errors in `SocketIO.read` to surface
- drop print statements from `MoteIF` error handling

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0c7b85788327944c3e97a8ddc668