### PR TITLE
Fix SFProtocol length byte handling

### DIFF
--- a/tests/test_sfprotocol.py
+++ b/tests/test_sfprotocol.py
@@ -1,0 +1,20 @@
+from tinyos3.packet.SFProtocol import SFProtocol
+
+class DummyIO:
+    def __init__(self):
+        self.written = []
+    def write(self, data):
+        self.written.append(data)
+    def flush(self):
+        pass
+
+
+def test_write_packet_sends_length_as_byte():
+    io = DummyIO()
+    prot = SFProtocol(io, io)
+    pkt = b"\x01\x02\x03"
+
+    prot.writePacket(pkt)
+
+    assert io.written[0] == bytes([len(pkt)])
+    assert io.written[1] == pkt

--- a/tinyos3/packet/SFProtocol.py
+++ b/tinyos3/packet/SFProtocol.py
@@ -72,6 +72,6 @@ class SFProtocol:
         if len(packet) > 255:
             raise SFProtocolException("packet too long")
 
-        self.outs.write(chr(len(packet)))
+        self.outs.write(bytes([len(packet)]))
         self.outs.write(packet)
         self.outs.flush()


### PR DESCRIPTION
## Summary
- fix `SFProtocol.writePacket` to send the length prefix as bytes
- add unit test covering the behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3cb551148327b47571910fd43833