### PR TITLE
Remove unnecessary global keywords

### DIFF
--- a/tinyos3/packet/PacketSource.py
+++ b/tinyos3/packet/PacketSource.py
@@ -43,8 +43,6 @@ runner = ThreadTaskRunner()
 
 
 def finishAll():
-    global runner
-
     runner.cancelAll()
     runner.finish()
 
@@ -56,7 +54,6 @@ class PacketSourceException(Exception):
 
 class PacketSource(ThreadTask):
     def __init__(self, dispatcher):
-        global runner
         ThreadTask.__init__(self, runner)
         self.dispatcher = dispatcher
         self.semaphore = Semaphore(1)
@@ -89,7 +86,6 @@ class PacketSource(ThreadTask):
         self.finish()
 
     def start(self):
-        global runner
         runner.start(self)
 
     def open(self):


### PR DESCRIPTION
## Summary
- restore original PacketSource threading mechanism
- drop redundant `global runner` declarations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da64dedd48327beb0ef417914771d