### PR TITLE
Retry PacketSource open on OSError

### DIFF
--- a/tests/test_packetsource.py
+++ b/tests/test_packetsource.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from tinyos3.packet.PacketSource import PacketSource
+from tinyos3.packet.IO import IODone
+
+
+class DummyDispatcher:
+    def dispatchPacket(self, source, packet):
+        pass
+
+
+class FlakySource(PacketSource):
+    def __init__(self, fail_times=1):
+        PacketSource.__init__(self, DummyDispatcher())
+        self.fail_times = fail_times
+        self.attempts = 0
+
+    def open(self):
+        self.attempts += 1
+        if self.attempts <= self.fail_times:
+            raise ConnectionRefusedError()
+
+    def readPacket(self):
+        raise IODone()
+
+
+def test_retries_until_open_succeeds():
+    src = FlakySource(fail_times=2)
+    with patch("tinyos3.packet.PacketSource.time.sleep", return_value=None) as sleep:
+        src.__call__()
+
+    assert src.attempts == 3
+    assert sleep.call_count == 2
+

--- a/tinyos3/packet/PacketSource.py
+++ b/tinyos3/packet/PacketSource.py
@@ -31,6 +31,7 @@
 import logging
 import signal
 import sys
+import time
 import traceback
 
 from .IO import *
@@ -61,7 +62,16 @@ class PacketSource(ThreadTask):
 
     def __call__(self):
         try:
-            self.open()
+            while True:
+                try:
+                    self.open()
+                    break
+                except OSError as e:
+                    if self.isDone():
+                        self.finish()
+                        return
+                    logger.debug("open failed: %s", e)
+                    time.sleep(1)
         finally:
             self.semaphore.release()
 


### PR DESCRIPTION
## Summary
- retry PacketSource.open until connection succeeds, waiting between attempts
- add unit test covering retry behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a338fa3b908327937ff47376f65750